### PR TITLE
Make Regex for extensions case insensitive

### DIFF
--- a/jQuery.imgx.js
+++ b/jQuery.imgx.js
@@ -35,8 +35,8 @@
         
             var src;
 
-            if (x2) src = $(this).attr('src').replace(/\.(gif|jpg|jpeg|png|webp)$/,'@2x.$1');
-            if (x3) src = $(this).attr('src').replace(/\.(gif|jpg|jpeg|png|webp)$/,'@3x.$1');
+            if (x2) src = $(this).attr('src').replace(/\.(gif|jpg|jpeg|png|webp)$/i,'@2x.$1');
+            if (x3) src = $(this).attr('src').replace(/\.(gif|jpg|jpeg|png|webp)$/i,'@3x.$1');
                           $(this).attr('src', src);
         });      
     };


### PR DESCRIPTION
Extensions for images, esp. jpeg, may be uppercase. This script would fail with a `.JPEG` extension without the `i` case insensitive flag. :palm_tree: 